### PR TITLE
Update marketing blog links

### DIFF
--- a/site/buy.html
+++ b/site/buy.html
@@ -375,14 +375,12 @@
             <span>X (Twitter)</span>
           </a>
           <a
-            href="https://liberdus.substack.com/"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-              <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"></path>
-            </svg>
-            <span>Substack</span>
+            <span class="community-icon rss" aria-hidden="true"></span>
+            <span>Blog</span>
           </a>
           <a
             href="https://www.youtube.com/@Liberdus"

--- a/site/download/index.html
+++ b/site/download/index.html
@@ -233,16 +233,12 @@
           </a>
 
           <a
-            href="https://liberdus.substack.com"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <img
-              src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/substack.svg"
-              alt="Substack"
-              class="community-logo"
-            />
-            <span class="community-text">Substack</span>
+            <span class="community-logo community-icon rss" aria-hidden="true"></span>
+            <span class="community-text">Blog</span>
           </a>
 
           <a

--- a/site/footer.html
+++ b/site/footer.html
@@ -31,8 +31,8 @@
                 >Discord</a
               >
               <a href="https://x.com/liberdus" target="_blank">X (Twitter)</a>
-              <a href="https://liberdus.substack.com" target="_blank"
-                >Substack</a
+              <a href="/blog" target="_blank"
+                >Blog</a
               >
               <a href="https://www.youtube.com/@Liberdus" target="_blank"
                 >YouTube</a

--- a/site/funding.html
+++ b/site/funding.html
@@ -324,14 +324,12 @@
             <span>X (Twitter)</span>
           </a>
           <a
-            href="https://liberdus.substack.com/"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-              <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"></path>
-            </svg>
-            <span>Substack</span>
+            <span class="community-icon rss" aria-hidden="true"></span>
+            <span>Blog</span>
           </a>
           <a
             href="https://www.youtube.com/@Liberdus"

--- a/site/index.html
+++ b/site/index.html
@@ -472,16 +472,12 @@
           </a>
 
           <a
-            href="https://liberdus.substack.com"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <img
-              src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/substack.svg"
-              alt="Substack"
-              class="community-logo"
-            />
-            <span class="community-text">Substack</span>
+            <span class="community-logo community-icon rss" aria-hidden="true"></span>
+            <span class="community-text">Blog</span>
           </a>
           
           <a

--- a/site/roadmap.html
+++ b/site/roadmap.html
@@ -213,16 +213,12 @@
           </a>
 
           <a
-            href="https://liberdus.substack.com"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <img
-              src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/substack.svg"
-              alt="Substack"
-              class="community-logo"
-            />
-            <span class="community-text">Substack</span>
+            <span class="community-logo community-icon rss" aria-hidden="true"></span>
+            <span class="community-text">Blog</span>
           </a>
 
           <a

--- a/site/sell.html
+++ b/site/sell.html
@@ -375,14 +375,12 @@
             <span>X (Twitter)</span>
           </a>
           <a
-            href="https://liberdus.substack.com/"
+            href="/blog"
             class="community-link"
             target="_blank"
           >
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-              <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"></path>
-            </svg>
-            <span>Substack</span>
+            <span class="community-icon rss" aria-hidden="true"></span>
+            <span>Blog</span>
           </a>
           <a
             href="https://www.youtube.com/@Liberdus"

--- a/site/src/styles/main.css
+++ b/site/src/styles/main.css
@@ -1596,6 +1596,13 @@ body {
   filter: invert(0.3) sepia(1) saturate(3) hue-rotate(220deg) drop-shadow(0 2px 4px rgba(99, 102, 241, 0.4));
 }
 
+.community-logo.community-icon,
+.community-link:hover .community-logo.community-icon,
+[data-theme="light"] .community-logo.community-icon,
+[data-theme="light"] .community-link:hover .community-logo.community-icon {
+  filter: none;
+}
+
 .community-text {
   font-weight: 700;
 }
@@ -3542,8 +3549,11 @@ html[data-theme="light"] .page-header #sell-bg {
   background-color: currentColor;
   -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
   -webkit-mask-size: contain;
   mask-size: contain;
+  flex: 0 0 auto;
 }
 
 .community-icon.discord {
@@ -3576,9 +3586,9 @@ html[data-theme="light"] .page-header #sell-bg {
   mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24'%3E%3Cpath d='M12 0c-6.626 0-12 5.373-12 12c0 5.302 3.438 9.8 8.207 11.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416c-.546-1.387-1.333-1.756-1.333-1.756c-1.089-.745.083-.729.083-.729c1.205.084 1.839 1.237 1.839 1.237c1.07 1.834 2.807 1.304 3.492.997c.107-.775.418-1.305.762-1.604c-2.665-.305-5.467-1.334-5.467-5.931c0-1.311.469-2.381 1.236-3.221c-.124-.303-.535-1.524.117-3.176c0 0 1.008-.322 3.301 1.23c.957-.266 1.983-.399 3.003-.404c1.02.005 2.047.138 3.006.404c2.291-1.552 3.297-1.23 3.297-1.23c.653 1.653.242 2.874.118 3.176c.77.84 1.235 1.911 1.235 3.221c0 4.609-2.807 5.624-5.479 5.921c.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576c4.765-1.589 8.199-6.086 8.199-11.386c0-6.627-5.373-12-12-12z'%3E%3C/path%3E%3C/svg%3E");
 }
 
-.community-icon.substack {
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24'%3E%3Cpath d='M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z'%3E%3C/path%3E%3C/svg%3E");
-  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24'%3E%3Cpath d='M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z'%3E%3C/path%3E%3C/svg%3E");
+.community-icon.rss {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20role%3D%27img%27%20viewBox%3D%270%200%2024%2024%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20fill%3D%27black%27%20d%3D%27M19.199%2024C19.199%2013.467%2010.533%204.8%200%204.8V0c13.165%200%2024%2010.835%2024%2024h-4.801zM3.291%2017.415c1.814%200%203.293%201.479%203.293%203.295%200%201.813-1.485%203.29-3.301%203.29C1.47%2024%200%2022.526%200%2020.71s1.475-3.294%203.291-3.295zM15.909%2024h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727%200%2015.909%207.184%2015.909%2015.91z%27%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg%20role%3D%27img%27%20viewBox%3D%270%200%2024%2024%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20fill%3D%27black%27%20d%3D%27M19.199%2024C19.199%2013.467%2010.533%204.8%200%204.8V0c13.165%200%2024%2010.835%2024%2024h-4.801zM3.291%2017.415c1.814%200%203.293%201.479%203.293%203.295%200%201.813-1.485%203.29-3.301%203.29C1.47%2024%200%2022.526%200%2020.71s1.475-3.294%203.291-3.295zM15.909%2024h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727%200%2015.909%207.184%2015.909%2015.91z%27%2F%3E%3C%2Fsvg%3E");
 }
 
 /* Buy/Sell Page Specific Styles */


### PR DESCRIPTION
## Summary

- Replace marketing-site Substack links with root-relative `/blog` links.
- Update visible labels from Substack to Blog in served `/site` pages.
- Centralize the RSS blog icon in shared CSS and use the reusable icon class in community links.
<img width="1002" height="491" alt="image" src="https://github.com/user-attachments/assets/b2925c48-c4e7-4ab5-8ac4-9d527e1e0e49" />

